### PR TITLE
Replace maven-compiler-plugin configuration with nullability-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-Sample Maven project showing [NullAway](https://github.com/uber/NullAway) configured with the JSpecify mode.
+Sample Maven project showing [NullAway](https://github.com/uber/NullAway) configured with the JSpecify mode via [nullability-maven-plugin](https://github.com/making/nullability-maven-plugin).
 A nullness issue is visible in IDEs with support for JSpecify or when running `./mvnw clean package`.

--- a/pom.xml
+++ b/pom.xml
@@ -24,38 +24,19 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.14.1</version>
-				<configuration>
-					<release>17</release>
-					<encoding>UTF-8</encoding>
-					<fork>true</fork>
-					<compilerArgs>
-						<arg>-XDcompilePolicy=simple</arg>
-						<arg>--should-stop=ifError=FLOW</arg>
-						<arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked -XepOpt:NullAway:JSpecifyMode=true</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-						<arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-						<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-						<arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
-					</compilerArgs>
-					<annotationProcessorPaths>
-						<path>
-							<groupId>com.google.errorprone</groupId>
-							<artifactId>error_prone_core</artifactId>
-							<version>2.42.0</version>
-						</path>
-						<path>
-							<groupId>com.uber.nullaway</groupId>
-							<artifactId>nullaway</artifactId>
-							<version>0.13.2</version>
-						</path>
-					</annotationProcessorPaths>
-				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>am.ik.maven</groupId>
+				<artifactId>nullability-maven-plugin</artifactId>
+				<version>0.3.0</version>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<goals>
+							<goal>configure</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
`package-info.java` is kept to maintain the contrast with the Gradle sample, although it can also be generated by the plugin.